### PR TITLE
Relax test for 8.4 "refcount" vs "packed refcount"

### DIFF
--- a/tests/serialize/backref.phpt
+++ b/tests/serialize/backref.phpt
@@ -30,16 +30,16 @@ array(1) {
   *RECURSION*
 }
 [[R::r::1],["a",r::4,o::{},r::5,[1,2,3],r::6],r::3,r::4,r::5,r::6]
-array(6) refcount(2){
+array(6) %sefcount(2){
   [0]=>
-  array(1) refcount(2){
+  array(1) %sefcount(2){
     [0]=>
     reference refcount(1) {
       *RECURSION*
     }
   }
   [1]=>
-  array(6) refcount(2){
+  array(6) %sefcount(2){
     [0]=>
     string(1) "a" refcount(3)
     [1]=>
@@ -51,7 +51,7 @@ array(6) refcount(2){
     object(stdClass)#%d (0) refcount(3){
     }
     [4]=>
-    array(3) refcount(3){
+    array(3) %sefcount(3){
       [0]=>
       int(1)
       [1]=>
@@ -60,7 +60,7 @@ array(6) refcount(2){
       int(3)
     }
     [5]=>
-    array(3) refcount(3){
+    array(3) %sefcount(3){
       [0]=>
       int(1)
       [1]=>
@@ -70,7 +70,7 @@ array(6) refcount(2){
     }
   }
   [2]=>
-  array(6) refcount(2){
+  array(6) %sefcount(2){
     [0]=>
     string(1) "a" refcount(3)
     [1]=>
@@ -82,7 +82,7 @@ array(6) refcount(2){
     object(stdClass)#%d (0) refcount(3){
     }
     [4]=>
-    array(3) refcount(3){
+    array(3) %sefcount(3){
       [0]=>
       int(1)
       [1]=>
@@ -91,7 +91,7 @@ array(6) refcount(2){
       int(3)
     }
     [5]=>
-    array(3) refcount(3){
+    array(3) %sefcount(3){
       [0]=>
       int(1)
       [1]=>
@@ -106,7 +106,7 @@ array(6) refcount(2){
   object(stdClass)#%d (0) refcount(3){
   }
   [5]=>
-  array(3) refcount(3){
+  array(3) %sefcount(3){
     [0]=>
     int(1)
     [1]=>

--- a/tests/serialize/serializable.phpt
+++ b/tests/serialize/serializable.phpt
@@ -85,7 +85,7 @@ Deprecated: recursive implements the Serializable interface, which is deprecated
 Deprecated: except implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary) in %sserialize/serializable.php on line %d
 
 [S::test::{{"foobar"}},r::1]
-array(2) refcount(2){
+array(2) %sefcount(2){
   [0]=>
   object(test)#%d (1) refcount(2){
     ["data":protected]=>


### PR DESCRIPTION
Using 8.4.0RC1 and this patch

```
=====================================================================
TEST RESULT SUMMARY
---------------------------------------------------------------------
Exts skipped    :     0
Exts tested     :    17
---------------------------------------------------------------------

Number of tests :    53                52
Tests skipped   :     1 (  1.9%) --------
Tests warned    :     0 (  0.0%) (  0.0%)
Tests failed    :     0 (  0.0%) (  0.0%)
Tests passed    :    52 ( 98.1%) (100.0%)
---------------------------------------------------------------------
Time taken      : 0.102 seconds
=====================================================================

```